### PR TITLE
Made it also work for NPM

### DIFF
--- a/Set-PackageQuality.ps1
+++ b/Set-PackageQuality.ps1
@@ -62,16 +62,15 @@ function Set-PackageQuality
     $token = New-VSTSAuthenticationToken
     $releaseViewURL = "$basepackageurl/$feedName/nuget/packages/$packageId/versions/$($packageVersion)?api-version=3.0-preview.1"
     
-    #Queue a new build for this definition
-    $json = @"
-    {
-        "views": 
-            { "op":"add", 
-              "path":"/views/-", 
-              "value":"$packageQuality" }
-    },
-"@
-    $response = Invoke-RestMethod -Uri $releaseViewURL -Headers @{Authorization = $token}   -ContentType "application/json" -Method Patch -Body $json
+     $json = @{
+        views = @{
+            op = "add"
+            path = "/views/-"
+            value = "$releaseView"
+        }
+    }
+
+    $response = Invoke-RestMethod -Uri $releaseViewURL -Headers @{Authorization = $token}   -ContentType "application/json" -Method Patch -Body (ConvertTo-Json $json)
     return $response
 }
 

--- a/Set-PackageQuality.ps1
+++ b/Set-PackageQuality.ps1
@@ -1,5 +1,6 @@
 param
 (
+        [ValidateSet("nuget","npm")][string] $feedType = "nuget",
         [string] $feedName="",
         [string] $packageId="",
         [string] $packageVersion="",
@@ -50,6 +51,7 @@ function Set-PackageQuality
     [OutputType([object])]
     param
     (
+        [string] $feedType="nuget",
         [string] $feedName="",
         [string] $packageId="",
         [string] $packageVersion="",
@@ -58,7 +60,14 @@ function Set-PackageQuality
     )
 
     $token = New-VSTSAuthenticationToken
-    $releaseViewURL = "$basepackageurl/$feedName/nuget/packages/$packageId/versions/$($packageVersion)?api-version=3.0-preview.1"
+    
+    #API URL is slightly different for npm vs. nuget...
+    switch($feedType)
+    {
+        "npm" { $releaseViewURL = "$basepackageurl/$feedName/npm/$packageId/versions/$($packageVersion)?api-version=3.0-preview.1" }
+        "nuget" { $releaseViewURL = "$basepackageurl/$feedName/nuget/packages/$packageId/versions/$($packageVersion)?api-version=3.0-preview.1" }
+        default { $releaseViewURL = "$basepackageurl/$feedName/nuget/packages/$packageId/versions/$($packageVersion)?api-version=3.0-preview.1" }
+    }
     
      $json = @{
         views = @{
@@ -75,5 +84,5 @@ function Set-PackageQuality
 
 if (-not $pester)
 {
-    Set-PackageQuality -feedName $feedName -packageId $packageId -packageVersion $packageVersion -packageQuality $packageQuality
+    Set-PackageQuality -feedType $feedType -feedName $feedName -packageId $packageId -packageVersion $packageVersion -packageQuality $packageQuality
 }

--- a/Set-PackageQuality.ps1
+++ b/Set-PackageQuality.ps1
@@ -66,7 +66,7 @@ function Set-PackageQuality
         views = @{
             op = "add"
             path = "/views/-"
-            value = "$releaseView"
+            value = "$packageQuality"
         }
     }
 

--- a/Set-PackageQuality.ps1
+++ b/Set-PackageQuality.ps1
@@ -8,11 +8,9 @@ param
 )
 
 #global variables
-$baseurl = $env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI 
-$baseurl += $env:SYSTEM_TEAMPROJECT + "/_apis"
-$basepackageurl = $env:SYSTEM_TEAMFOUNDATIONSERVERURI  -replace ".visualstudio.com/", ".pkgs.visualstudio.com/DefaultCollection/_apis/packaging/feeds"
+$account = ($env:SYSTEM_TEAMFOUNDATIONSERVERURI -replace "https://(.*)\.visualstudio\.com/", '$1').split('.')[0]
+$basepackageurl = ("https://{0}.pkgs.visualstudio.com/DefaultCollection/_apis/packaging/feeds" -f $account)
 
-Write-Debug  "baseurl=$baseurl"
 Write-Debug  "basepackageurl=$basepackageurl"
 
 <#

--- a/Test-SetPackageQuality.ps1
+++ b/Test-SetPackageQuality.ps1
@@ -7,10 +7,11 @@ cd $PSScriptRoot
 
 . .\Set-PackageQuality.ps1 -pester
 
+$feedType = "nuget"
 $feedName = "Feedname"
 $packageId = "packageID" 
 $packageVersion = "Version"
 $packageQuality = "ReleaseViewName"
 
-Set-PackageQuality -feedName $feedName -packageId $packageId -packageVersion $packageVersion -packageQuality $packageQuality
+Set-PackageQuality -feedType $feedType -feedName $feedName -packageId $packageId -packageVersion $packageVersion -packageQuality $packageQuality
 


### PR DESCRIPTION
Made it also work for NPM. To accomodate that, I've added a $feedType parameter, which can be either 'npm' or 'nuget'. Defaults to nuget.